### PR TITLE
CSRF - POST form support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ const csrfSync = csrfSync({
     req.session.csrfToken = token;
   }, // Used to store the token in state.
   size = 128, // The size of the generated tokens in bits
-}):
+});
 ```
 
 <h3>Processing as a form</h3>
@@ -192,7 +192,17 @@ const csrfSync = csrfSync({
     req.session.csrfToken = token;
   }, // Used to store the token in state.
   size = 128, // The size of the generated tokens in bits
-}):
+});
+```
+
+If using this with something like `express` you would need to provide/configure body parsing middleware before the CSRF protection.
+
+If doing this per route, you would for example:
+
+```js
+app.post('/route/', express.urlencoded({ extended: true }), csrfSynchronisedProtection, async (req, res) => {
+    //process the form as we passed CSRF
+})
 ```
 
 <h2 id="support"> Support</h2>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="#support">Support</a>
 </p>
 
-<h2 id="background"> Background</h2>
+<h2 id="background">Background</h2>
 
 <p>
   This module intends to provide the necessary pieces required to implement CSRF protection using the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern">Synchroniser Token Pattern</a>. This means you will require server side state, if you require stateless CSRF protection, please see <a href="some-url">csrf-csrf</a> for the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#double-submit-cookie">Double-Submit Cookie Pattern</a>.
@@ -169,7 +169,7 @@ const csrfSync = csrfSync({
 
 <h3>Processing as a form</h3>
 
-In you intend to use this module to protect user submitted forms, then you can use `generateToken` to create a token and pass it to your view, likely via template variables. Then using a hidden form input such as the example from the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern">Cheat Sheet</a>.
+If you intend to use this module to protect user submitted forms, then you can use `generateToken` to create a token and pass it to your view, likely via template variables. Then using a hidden form input such as the example from the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern">Cheat Sheet</a>.
 
 ```html
 <form action="/transfer.do" method="post">

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ const { csrfSYnc } = require("csrf-sync");
 const {
   invalidCsrfTokenError, // This is just for convenience if you plan on making your own middleware.
   generateToken, // Use this in your routes to generate, store, and get a CSRF token.
+  getTokenFromRequest, // use this to retrieve the token submitted by a user
   getTokenFromState, // The default method for retrieving a token from state.
   storeTokenInState, // The default method for storing a token in state.
   revokeToken, // Revokes/deletes a token by calling storeTokenInState(undefined)
@@ -147,6 +148,8 @@ Once a route is protected, you will need to include the most recently generated 
 
 <h2 id="configuration">Configuration</h2>
 
+<h3>Processing as a header</h3>
+
 When creating your csrfSync, you have a few options available for configuration, all of them are optional and have sensible defaults (shown below).
 
 ```js
@@ -154,10 +157,40 @@ const csrfSync = csrfSync({
   getTokenFromState = (req) => {
     return req.session.csrfToken;
   }, // Used to retrieve the token from state.
+  getTokenFromRequest = (req) =>  {
+    return req.headers['x-csrf-token'];
+  }, // Used to retrieve the token submitted by the request from headers
   storeTokenInState = (req, token) => {
     req.session.csrfToken = token;
   }, // Used to store the token in state.
-  header = "x-csrf-token", // The header name where the token is on incoming requests.
+  size = 128, // The size of the generated tokens in bits
+}):
+```
+
+<h3>Processing as a form</h3>
+
+In you intend to use this module to protect user submitted forms, then you can use `generateToken` to create a token and pass it to your view, likely via template variables. Then using a hidden form input such as the example from the <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern">Cheat Sheet</a>.
+
+```html
+<form action="/transfer.do" method="post">
+<input type="hidden" name="CSRFToken" value="OWY4NmQwODE4ODRjN2Q2NTlhMmZlYWEwYzU1YWQwMTVhM2JmNGYxYjJiMGI4MjJjZDE1ZDZMGYwMGEwOA==">
+[...]
+</form>
+```
+
+Upon form submission a `csrfSync` configured as follows can be used to protect the form.
+
+```js
+const csrfSync = csrfSync({
+  getTokenFromState = (req) => {
+    return req.session.csrfToken;
+  }, // Used to retrieve the token from state.
+  getTokenFromRequest = (req) =>  {
+    return req.body['CSRFToken'];
+  }, // Used to retrieve the token submitted by the user in a form
+  storeTokenInState = (req, token) => {
+    req.session.csrfToken = token;
+  }, // Used to store the token in state.
   size = 128, // The size of the generated tokens in bits
 }):
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export const csrfSync = ({
   },
   header = "x-csrf-token",
   size = 128,
+  form = '_csrf',
 }: CsrfSyncOptions = {}): CsrfSync => {
   const invalidCsrfTokenError = createHttpError(403, "invalid csrf token", {
     code: "EBADCSRFTOKEN",
@@ -63,7 +64,7 @@ export const csrfSync = ({
   };
 
   const isRequestValid: CsrfRequestValidator = (req) => {
-    const receivedToken = req.headers[header];
+    const receivedToken =  (req.body && req.body._csrf) || req.headers[header];
     const storedToken = getTokenFromState(req);
 
     return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export interface CsrfSyncOptions {
   storeTokenInState?: CsrfTokenStorer;
   header?: string;
   size?: number;
+  form?: string;
 }
 
 export interface CsrfSync {
@@ -64,7 +65,7 @@ export const csrfSync = ({
   };
 
   const isRequestValid: CsrfRequestValidator = (req) => {
-    const receivedToken =  (req.body && req.body._csrf) || req.headers[header];
+    const receivedToken =  (req.body && req.body[form]) || req.headers[header];
     const storedToken = getTokenFromState(req);
 
     return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ declare module "express-session" {
 }
 
 export type CsrfSyncedToken = string | null | undefined;
+export type CsrfRequestToken = string | undefined;
 export type CsrfTokenStorer = (req: Request, token?: CsrfSyncedToken) => void;
-export type CsrfTokenRequest = (req: Request) => string | string[] | undefined;
 export type CsrfTokenRetriever = (req: Request) => CsrfSyncedToken;
 export type CsrfTokenGenerator = (req: Request) => string;
 export type CsrfTokenRevoker = (req: Request) => void;
@@ -22,7 +22,7 @@ export type CsrfSynchronisedProtection = (
 ) => void;
 
 export interface CsrfSyncOptions {
-  getTokenFromRequest?: CsrfTokenRequest;
+  getTokenFromRequest?: CsrfTokenRetriever;
   getTokenFromState?: CsrfTokenRetriever;
   storeTokenInState?: CsrfTokenStorer;
   size?: number;
@@ -32,7 +32,7 @@ export interface CsrfSync {
   invalidCsrfTokenError: HttpError;
   csrfSynchronisedProtection: CsrfSynchronisedProtection;
   generateToken: CsrfTokenGenerator;
-  getTokenFromRequest: CsrfTokenRequest;
+  getTokenFromRequest: CsrfTokenRetriever;
   getTokenFromState: CsrfTokenRetriever;
   isRequestValid: CsrfRequestValidator;
   storeTokenInState: CsrfTokenStorer;
@@ -40,7 +40,7 @@ export interface CsrfSync {
 }
 
 export const csrfSync = ({
-  getTokenFromRequest = (req) => req.headers['x-csrf-token'],
+  getTokenFromRequest = (req) => req.headers['x-csrf-token'] as CsrfRequestToken,
   getTokenFromState = (req) => {
     return req.session.csrfToken;
   },

--- a/src/tests/csrfsync.test.ts
+++ b/src/tests/csrfsync.test.ts
@@ -3,131 +3,17 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { assert, expect } from "chai";
-import { csrfSync } from "../index.js";
-import { Request, Response } from "express";
+import { CsrfRequestToken, csrfSync } from "../index.js";
+import csrfSyncTestSuite from "./suite/csrfsync";
 
-describe("csrf-sync", () => {
-  const {
-    invalidCsrfTokenError,
-    csrfSynchronisedProtection,
-    generateToken,
-    getTokenFromState,
-    storeTokenInState,
-    revokeToken,
-  } = csrfSync();
+csrfSyncTestSuite(
+  "csrfSync default config",
+  csrfSync(),
+  (req, tokenValue) => { req.headers['x-csrf-token'] = tokenValue });
 
-  const generateMocks = () => {
-    const mockRequest = {
-      session: {
-        csrfToken: undefined,
-      },
-      headers: {},
-    } as unknown as Request;
-    const mockResponse = {} as unknown as Response;
-    return {
-      mockRequest,
-      mockResponse,
-    };
-  };
-
-  const next = (err: any) => {
-    if (err) throw err;
-  };
-
-  const HEADER_KEY = "x-csrf-token";
-  const TEST_TOKEN = "test token";
-
-  describe("storeTokenInState", () => {
-    it("should store the token in the session", () => {
-      const { mockRequest } = generateMocks();
-      storeTokenInState(mockRequest, TEST_TOKEN);
-
-      assert.equal(mockRequest.session.csrfToken, TEST_TOKEN);
-    });
-  });
-
-  describe("generateToken", () => {
-    it("should generate a token and store it on the session", () => {
-      const { mockRequest } = generateMocks();
-
-      assert.equal(mockRequest.session.csrfToken, undefined);
-      generateToken(mockRequest);
-      assert.equal(
-        mockRequest.session.csrfToken,
-        getTokenFromState(mockRequest)
-      );
-    });
-  });
-
-  describe("middleware", () => {
-    const assertThrowsInvalidCsrfError = (
-      mockRequest: Request,
-      mockResponse: Response
-    ) => {
-      expect(() =>
-        csrfSynchronisedProtection(mockRequest, mockResponse, next)
-      ).to.throw(invalidCsrfTokenError.message);
-    };
-
-    it("should call next with an error when no token set", () => {
-      const { mockRequest, mockResponse } = generateMocks();
-
-      assert.isUndefined(mockRequest.headers[HEADER_KEY]);
-      assert.isUndefined(mockRequest.session.csrfToken);
-
-      assertThrowsInvalidCsrfError(mockRequest, mockResponse);
-    });
-
-    it("should call next with an error when no token received", () => {
-      const { mockRequest, mockResponse } = generateMocks();
-      generateToken(mockRequest);
-      mockRequest.headers[HEADER_KEY] = undefined;
-
-      assert.isUndefined(mockRequest.headers[HEADER_KEY]);
-      expect(mockRequest.session.csrfToken).to.not.be.undefined;
-
-      assertThrowsInvalidCsrfError(mockRequest, mockResponse);
-    });
-
-    it("should call next with an error when tokens do not match", () => {
-      const { mockRequest, mockResponse } = generateMocks();
-      generateToken(mockRequest);
-      mockRequest.headers[HEADER_KEY] = TEST_TOKEN;
-
-      assert.notEqual(
-        mockRequest.headers[HEADER_KEY],
-        mockRequest.session.csrfToken
-      );
-
-      assertThrowsInvalidCsrfError(mockRequest, mockResponse);
-    });
-
-    it("should call next with an error when token is revoked", () => {
-      const { mockRequest, mockResponse } = generateMocks();
-      const token = generateToken(mockRequest);
-      mockRequest.headers[HEADER_KEY] = token;
-
-      expect(mockRequest.session.csrfToken).to.not.be.undefined;
-      assert.equal(
-        mockRequest.headers[HEADER_KEY],
-        mockRequest.session.csrfToken
-      );
-
-      revokeToken(mockRequest);
-
-      assert.isUndefined(mockRequest.session.csrfToken);
-      assertThrowsInvalidCsrfError(mockRequest, mockResponse);
-    });
-
-    it("should succeed when tokens match", () => {
-      const { mockRequest, mockResponse } = generateMocks();
-      const token = generateToken(mockRequest);
-      mockRequest.headers[HEADER_KEY] = token;
-
-      expect(() =>
-        csrfSynchronisedProtection(mockRequest, mockResponse, next)
-      ).to.not.throw();
-    });
-  });
-});
+csrfSyncTestSuite(
+  "csrfSync with body based token", 
+  csrfSync({
+    getTokenFromRequest: req => req.body.csrfToken as CsrfRequestToken,
+  }), 
+  (req, tokenValue) => req.body.csrfToken = tokenValue);

--- a/src/tests/suite/csrfsync.ts
+++ b/src/tests/suite/csrfsync.ts
@@ -1,0 +1,136 @@
+import { assert, expect } from "chai";
+import { Request, Response } from "express";
+import { CsrfRequestToken, CsrfSync } from "../../index.js";
+
+export type OverwriteMockRequestToken = (req: Request, tokenValue: CsrfRequestToken) => void;
+
+export default (
+  testSuiteName: string,
+  {
+    invalidCsrfTokenError,
+    csrfSynchronisedProtection,
+    generateToken,
+    getTokenFromRequest,
+    getTokenFromState,
+    storeTokenInState,
+    revokeToken,
+  }: CsrfSync,
+  overwriteMockRequestToken: OverwriteMockRequestToken) => {
+  describe(testSuiteName, () => {
+    const generateMocks = () => {
+      const mockRequest = {
+        session: {
+          csrfToken: undefined,
+        },
+        headers: {},
+        body: {},
+      } as unknown as Request;
+      const mockResponse = {} as unknown as Response;
+      return {
+        mockRequest,
+        mockResponse,
+      };
+    };
+
+    const next = (err: any) => {
+      if (err) throw err;
+    };
+
+    const TEST_TOKEN = "test token";
+
+    describe("storeTokenInState", () => {
+      it("should store the token in the state", () => {
+        const { mockRequest } = generateMocks();
+        storeTokenInState(mockRequest, TEST_TOKEN);
+
+        assert.equal(getTokenFromState(mockRequest), TEST_TOKEN);
+      });
+    });
+
+    describe("generateToken", () => {
+      it("should generate a token and store it on the session", () => {
+        const { mockRequest } = generateMocks();
+
+        assert.equal(mockRequest.session.csrfToken, undefined);
+        generateToken(mockRequest);
+        // This is confirming the 2 values are the same
+        // So that getTokenFromState can be used reliably in the tests.
+        assert.equal(
+          mockRequest.session.csrfToken,
+          getTokenFromState(mockRequest)
+        );
+      });
+    });
+
+    describe("middleware", () => {
+      const assertThrowsInvalidCsrfError = (
+        mockRequest: Request,
+        mockResponse: Response
+      ) => {
+        expect(() =>
+          csrfSynchronisedProtection(mockRequest, mockResponse, next)
+        ).to.throw(invalidCsrfTokenError.message);
+      };
+
+      it("should call next with an error when no token set", () => {
+        const { mockRequest, mockResponse } = generateMocks();
+
+        assert.isUndefined(getTokenFromRequest(mockRequest));
+        assert.isUndefined(getTokenFromState(mockRequest));
+
+        assertThrowsInvalidCsrfError(mockRequest, mockResponse);
+      });
+
+      it("should call next with an error when no token received", () => {
+        const { mockRequest, mockResponse } = generateMocks();
+        generateToken(mockRequest);
+        overwriteMockRequestToken(mockRequest, undefined);
+
+        assert.isUndefined(getTokenFromRequest(mockRequest));
+        expect(getTokenFromState(mockRequest)).to.not.be.undefined;
+
+        assertThrowsInvalidCsrfError(mockRequest, mockResponse);
+      });
+
+      it("should call next with an error when tokens do not match", () => {
+        const { mockRequest, mockResponse } = generateMocks();
+        generateToken(mockRequest);
+        overwriteMockRequestToken(mockRequest, TEST_TOKEN);
+
+        assert.notEqual(
+          getTokenFromRequest(mockRequest),
+          getTokenFromState(mockRequest)
+        );
+
+        assertThrowsInvalidCsrfError(mockRequest, mockResponse);
+      });
+
+      it("should call next with an error when token is revoked", () => {
+        const { mockRequest, mockResponse } = generateMocks();
+        const token = generateToken(mockRequest);
+        overwriteMockRequestToken(mockRequest, token);
+
+        expect(mockRequest.session.csrfToken).to.not.be.undefined;
+        assert.equal(
+          getTokenFromRequest(mockRequest),
+          getTokenFromState(mockRequest)
+        );
+
+        revokeToken(mockRequest);
+
+        assert.isUndefined(getTokenFromState(mockRequest));
+        assertThrowsInvalidCsrfError(mockRequest, mockResponse);
+      });
+
+      it("should succeed when tokens match", () => {
+        const { mockRequest, mockResponse } = generateMocks();
+        const token = generateToken(mockRequest);
+        overwriteMockRequestToken(mockRequest, token);
+
+        expect(() =>
+          csrfSynchronisedProtection(mockRequest, mockResponse, next)
+        ).to.not.throw();
+      });
+    });
+  });
+}


### PR DESCRIPTION
This PR addresses the issue I just ran into and highlighted and fixes #4 when attempting to migrate from express CSRF

It adds the ability for `isRequestValid` to check the inbound POST form for a CSRF token and validate it.
Currenty it priortises the form over the header.

The default POST form key is `_csrf` and can be overriden in options.

I've not revised the wording in the README for this change (or made any changes to any tests)