### PR TITLE
feat: expose generateToken via req.csrfToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ Once a route is protected, you will need to include the most recently generated 
 generateToken(req, true); // This will force a new token to be generated, even if one already exists
 ```
 
+<p>Instead of importing and using <code>generateToken</code>, you can also use <code>req.csrfToken</code> any time after the <code>csrfSynchronisedProtection` middleware has executed on your incoming request.</p>
+
+```js
+req.csrfToken(); // same as generateToken(req) and generateToken(req, false);
+req.csrfToken(true); // same as generateToken(req, true);
+```
+
 <h3>revokeToken</h3>
 
 By default tokens <b>will NOT be revoked</b>, if you want or need to revoke a token you should use this method to do so. Note that if you call <code>generateToken</code> with <code>overwrite</code> set to true, this will revoke the any existing token and only the new one will be valid.
@@ -234,6 +241,10 @@ const csrfSyncProtection = csrfSync({
   },
 });
 ```
+
+<h2>Using asynchronously</h2>
+
+<p>csrf-sync itself will not support promises or async, <b>however</b> there is a way around this. If your csrf t<p>
 
 <h2 id="support">Support</h2>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ declare module "express-session" {
   }
 }
 
+declare module "express-serve-static-core" {
+  export interface Request {
+    csrfToken?: (overwrite?: boolean) => ReturnType<CsrfTokenGenerator>;
+  }
+}
+
 export type RequestMethod =
   | "GET"
   | "HEAD"
@@ -101,6 +107,8 @@ export const csrfSync = ({
     res,
     next
   ) => {
+    req.csrfToken = (overwrite) => generateToken(req, overwrite);
+
     if (ignoredMethodsSet.has(req.method as RequestMethod)) {
       next();
     } else {

--- a/src/tests/suite/csrfsync.ts
+++ b/src/tests/suite/csrfsync.ts
@@ -169,5 +169,27 @@ export default (
 
       assert.notEqual(initialToken, secondaryToken);
     });
+
+    it("should attach generateToken to request via csrfToken", () => {
+      const { mockRequest, mockResponse } = generateMocks();
+      mockRequest.method = "GET";
+
+      assert.isUndefined(mockRequest.csrfToken);
+      csrfSynchronisedProtection(mockRequest, mockResponse, next);
+      assert.isFunction(mockRequest.csrfToken);
+      let reqGeneratedToken;
+
+      if (mockRequest.csrfToken) {
+        reqGeneratedToken = mockRequest.csrfToken();
+      }
+
+      assert.equal(reqGeneratedToken, generateToken(mockRequest, false));
+      overwriteMockRequestToken(mockRequest, reqGeneratedToken);
+      mockRequest.method = "POST";
+
+      expect(() => {
+        csrfSynchronisedProtection(mockRequest, mockResponse, next);
+      }).to.not.throw();
+    });
   });
 };


### PR DESCRIPTION
This exposes `generateToken` through `req.csrfToken` once the middleware has been passed through. This makes csrf-sync a lot more plug in and replace friendly with csruf, which also exposed a `csrfToken` method on the request object.