### PR TITLE
add types to export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/cjs/index.cjs",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/cjs/index.cjs",
       "import": "./lib/esm/index.js"
     }


### PR DESCRIPTION
"types" need to be inside "exports" in newer versions of TypeScript.
[Documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)

Otherwise the following error appears
```
Could not find a declaration file for module 'csrf-sync'. './node_modules/csrf-sync/lib/esm/index.js' implicitly has an 'any' type.
There are types at './node_modules/csrf-sync/lib/index.d.ts', but this result could not be resolved when respecting package.json "exports".
The 'csrf-sync' library may need to update its package.json or typings.
```