### PR TITLE
feat: add skipCsrfProtection configuration option

### DIFF
--- a/src/tests/skipCsrfProtection.test.ts
+++ b/src/tests/skipCsrfProtection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { csrfSync } from "../index.js";
+import { generateMocks, next } from "./utils/mock.js";
+
+describe("csrf-csrf with skipCsrfProtection", () => {
+  it("should skip CSRF protection when skipCsrfProtection returns true", () => {
+    const { csrfSynchronisedProtection } = csrfSync({
+      skipCsrfProtection: () => true,
+    });
+
+    const { mockResponse, mockRequest } = generateMocks();
+    expect(mockRequest.csrfToken).toBeUndefined();
+    expect(() => csrfSynchronisedProtection(mockRequest, mockResponse, next)).not.toThrow();
+    expect(mockRequest.csrfToken).toBeTypeOf("function");
+  });
+
+  const testSkipCsrfProtectionFalsey = (skipCsrfProtection?: any) => {
+    const { csrfSynchronisedProtection, generateToken } = csrfSync({
+      skipCsrfProtection,
+    });
+
+    const { mockResponse, mockRequest } = generateMocks(); // with token needed
+    mockRequest.headers["x-csrf-token"] = generateToken(mockRequest);
+
+    expect(mockRequest.csrfToken).toBeUndefined();
+    expect(() => csrfSynchronisedProtection(mockRequest, mockResponse, next)).not.toThrow();
+    expect(mockRequest.csrfToken).toBeTypeOf("function");
+  };
+
+  it("should not skip CSRF protection when skipCsrfProtection returns false", () => {
+    testSkipCsrfProtectionFalsey(() => false);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns null", () => {
+    testSkipCsrfProtectionFalsey(() => null);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns undefined", () => {
+    testSkipCsrfProtectionFalsey(() => undefined);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns empty string", () => {
+    testSkipCsrfProtectionFalsey(() => "");
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns empty object", () => {
+    testSkipCsrfProtectionFalsey(() => ({}));
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection returns 1", () => {
+    testSkipCsrfProtectionFalsey(() => 1);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection is null", () => {
+    testSkipCsrfProtectionFalsey(null);
+  });
+
+  it("should not skip CSRF protection when skipCsrfProtection is undefined", () => {
+    testSkipCsrfProtectionFalsey(undefined);
+  });
+});

--- a/src/tests/suite/csrfsync.ts
+++ b/src/tests/suite/csrfsync.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { describe, expect, it } from "vitest";
 import type { CsrfRequestToken, CsrfSync } from "../../types";
+import { generateMocks, next } from "../utils/mock";
 
 export type OverwriteMockRequestToken = (req: Request, tokenValue: CsrfRequestToken) => void;
 
@@ -18,26 +19,6 @@ export default (
   overwriteMockRequestToken: OverwriteMockRequestToken,
 ) => {
   describe(testSuiteName, () => {
-    const generateMocks = () => {
-      const mockRequest = {
-        session: {
-          csrfToken: undefined,
-        },
-        method: "POST",
-        headers: {},
-        body: {},
-      } as unknown as Request;
-      const mockResponse = {} as unknown as Response;
-      return {
-        mockRequest,
-        mockResponse,
-      };
-    };
-
-    const next = (err: any) => {
-      if (err) throw err;
-    };
-
     const TEST_TOKEN = "test token";
 
     describe("storeTokenInState", () => {

--- a/src/tests/utils/mock.ts
+++ b/src/tests/utils/mock.ts
@@ -1,0 +1,21 @@
+import type { Request, Response } from "express";
+
+export const generateMocks = () => {
+  const mockRequest = {
+    session: {
+      csrfToken: undefined,
+    },
+    method: "POST",
+    headers: {},
+    body: {},
+  } as unknown as Request;
+  const mockResponse = {} as unknown as Response;
+  return {
+    mockRequest,
+    mockResponse,
+  };
+};
+
+export const next = (err: any) => {
+  if (err) throw err;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface CsrfSyncOptions {
   storeTokenInState?: CsrfTokenStorer;
   size?: number;
   errorConfig?: CsrfErrorConfigOptions;
+  skipCsrfProtection?: (req: Request) => boolean;
 }
 
 export interface CsrfSync {


### PR DESCRIPTION
Adds the `skipCsrfProtection` option to the config. Optional, backwards compatible.